### PR TITLE
Use PropTypes from prop-types to be forwards-compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 import React, {
   Component,
-  PropTypes,
 } from 'react';
+
+import PropTypes from 'prop-types';
 
 import {
   StyleSheet,

--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "eslint": "^2.7.0",
     "eslint-config-airbnb": "^6.2.0",
     "eslint-plugin-react": "^4.2.3"
+  },
+  "dependencies": {
+    "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
React v15.5 moves PropTypes from the main React library into the
prop-types library.

(ref: https://facebook.github.io/react/warnings/dont-call-proptypes.html)

Fixes #18 