### PR TITLE
Use Android friendly libraries. 

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,170 +1,185 @@
 import React, {
-  Component,
+	Component,
 } from 'react';
 
 import PropTypes from 'prop-types';
 
 import {
-  StyleSheet,
-  Text,
-  TouchableOpacity,
-  View,
-  Modal,
-  Picker,
-  Dimensions,
-  TouchableWithoutFeedback,
+	StyleSheet,
+	Text,
+	TouchableOpacity,
+	View,
+	Modal,
+	Picker,
+	Dimensions,
+	TouchableWithoutFeedback,
 } from 'react-native';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 
 const styles = {
-  basicContainer: {
-    flex: 1,
-    justifyContent: 'flex-end',
-    alignItems: 'center',
-  },
+	basicContainer: {
+		flex: 1,
+		justifyContent: 'flex-end',
+		alignItems: 'center',
+	},
 
-  overlayContainer: {
-    flex: 1,
-    width: SCREEN_WIDTH,
-  },
+	overlayContainer: {
+		flex: 1,
+		width: SCREEN_WIDTH,
+	},
 
-  mainBox: {
-   // Can be used by <SimplePicker styles={{ mainBox:{...} }}/>
-  },
+	mainBox: {
+		// Can be used by <SimplePicker styles={{ mainBox:{...} }}/>
+	},
 
-  modalContainer: {
-    width: SCREEN_WIDTH,
-    justifyContent: 'center',
-    alignItems: 'center',
-    padding: 0,
-    backgroundColor: '#F5FCFF',
-  },
+	modalContainer: {
+		width: SCREEN_WIDTH,
+		justifyContent: 'center',
+		alignItems: 'center',
+		padding: 0,
+		backgroundColor: '#F5FCFF',
+	},
 
-  buttonView: {
-    width: SCREEN_WIDTH,
-    padding: 8,
-    borderTopWidth: 0.5,
-    borderTopColor: 'lightgrey',
-    justifyContent: 'space-between',
-    flexDirection: 'row',
-  },
+	buttonView: {
+		width: SCREEN_WIDTH,
+		padding: 8,
+		borderTopWidth: 0.5,
+		borderTopColor: 'lightgrey',
+		justifyContent: 'space-between',
+		flexDirection: 'row',
+	},
 
-  bottomPicker: {
-    width: SCREEN_WIDTH,
-  },
+	bottomPicker: {
+		width: SCREEN_WIDTH,
+	},
 };
 
 const propTypes = {
-  buttonColor: PropTypes.string,
-  buttonStyle: PropTypes.object,
-  cancelText: PropTypes.string,
-  confirmText: PropTypes.string,
-  disableOverlay: PropTypes.bool,
-  initialOptionIndex: PropTypes.number,
-  itemStyle: PropTypes.object,
-  labels: PropTypes.array,
-  modalVisible: PropTypes.bool,
-  onSubmit: PropTypes.func,
+	buttonColor: PropTypes.string,
+	buttonStyle: PropTypes.object,
+	cancelText: PropTypes.string,
+	confirmText: PropTypes.string,
+	disableOverlay: PropTypes.bool,
+	initialOptionIndex: PropTypes.number,
+	itemStyle: PropTypes.object,
+	labels: PropTypes.array,
+	modalVisible: PropTypes.bool,
+	onCancel: PropTypes.func,
+	onSubmit: PropTypes.func,
 	options: PropTypes.array.isRequired,
 	styles: PropTypes.object,
 };
+
+const booleanIsSet = (variable) => variable || String(variable) === 'false'
 
 class SimplePicker extends Component {
 	static defaultProps = {
 		styles: {}
 	};
+
 	constructor(props) {
-    super(props);
+		super(props);
 
-    const selected = props.initialOptionIndex || 0;
+		const selected = props.initialOptionIndex || 0;
 
-    this.state = {
-      modalVisible: props.modalVisible || false,
-      selectedOption: props.options[selected],
-    };
-		this.styles = StyleSheet.create({...styles, ...props.styles});
+		this.state = {
+			modalVisible: props.modalVisible || false,
+			selectedOption: props.options[selected],
+		};
+		this.styles = StyleSheet.create({ ...styles, ...props.styles });
 
 		this.onPressCancel = this.onPressCancel.bind(this);
-    this.onPressSubmit = this.onPressSubmit.bind(this);
-    this.onValueChange = this.onValueChange.bind(this);
-    this.onOverlayDismiss = this.onOverlayDismiss.bind(this);
+		this.onPressSubmit = this.onPressSubmit.bind(this);
+		this.onValueChange = this.onValueChange.bind(this);
+		this.onOverlayDismiss = this.onOverlayDismiss.bind(this);
 
-    if ('buttonColor' in props) {
-      console.warn('buttonColor as a prop is deprecated, please use buttonStyle instead.');
-    }
-  }
+		if ('buttonColor' in props) {
+			console.warn('buttonColor as a prop is deprecated, please use buttonStyle instead.');
+		}
+	}
 
-  componentWillReceiveProps(props) {
-    // If options are changing, and our current selected option is not part of
-    // the new options, update it.
-    if (
-      props.options
-      && props.options.length > 0
-      && props.options.indexOf(this.state.selectedOption) === -1
-    ) {
-      const previousOption = this.state.selectedOption;
-      this.setState({
-        selectedOption: props.options[0],
-      }, () => {
-        // Options array changed and the previously selected option is not present anymore.
-        // Should call onSubmit function to tell parent to handle the change too.
-        if (previousOption) {
-          this.onPressSubmit();
-        }
-      });
-    }
-  }
+	componentWillReceiveProps(props) {
+		// If options are changing, and our current selected option is not part of
+		// the new options, update it.
+		if (
+			props.options
+			&& props.options.length > 0
+			&& props.options.indexOf(this.state.selectedOption) === -1
+		) {
+			const previousOption = this.state.selectedOption;
+			this.setState({
+				selectedOption: props.options[0],
+			}, () => {
+				// Options array changed and the previously selected option is not present anymore.
+				// Should call onSubmit function to tell parent to handle the change too.
+				if (previousOption) {
+					this.onPressSubmit();
+				}
+			});
+		}
+		if (booleanIsSet(props.modalVisible)) {
+			this.setState({
+				modalVisible: props.modalVisible
+			})
+		}
+	}
 
-  onPressCancel() {
-    this.hide();
-  }
+	onPressCancel() {
+		if (this.props.onCancel) {
+			this.props.onCancel(this.state.selectedOption);
+		}
+		this.hide();
+	}
 
-  onPressSubmit() {
-    if (this.props.onSubmit) {
-      this.props.onSubmit(this.state.selectedOption);
-    }
+	onPressSubmit() {
+		if (this.props.onSubmit) {
+			this.props.onSubmit(this.state.selectedOption);
+		}
 
-    this.hide();
-  }
+		this.hide();
+	}
 
-  onOverlayDismiss() {
-    this.hide();
-  }
+	onOverlayDismiss() {
+		if (this.props.onCancel) {
+			this.props.onCancel(this.state.selectedOption);
+		}
+		this.hide();
+	}
 
-  onValueChange(option) {
-    this.setState({
-      selectedOption: option,
-    });
-  }
+	onValueChange(option) {
+		this.setState({
+			selectedOption: option,
+		});
+	}
 
-  show() {
-    this.setState({
-      modalVisible: true,
-    });
-  }
+	show() {
+		this.setState({
+			modalVisible: true,
+		});
+	}
 
-  hide() {
-    this.setState({
-      modalVisible: false,
-    });
-  }
+	hide() {
+		this.setState({
+			modalVisible: false,
+		});
+	}
 
-  renderItem(option, index) {
-    const label = (this.props.labels) ? this.props.labels[index] : option;
+	renderItem(option, index) {
+		const label = (this.props.labels) ? this.props.labels[index] : option;
 
-    return (
-      <Picker.Item
-        key={option}
-        value={option}
-        label={label}
-      />
-    );
-  }
+		return (
+			<Picker.Item
+				key={option}
+				value={option}
+				label={label}
+			/>
+		);
+	}
 
-  render() {
-    const { modalVisible, selectedOption } = this.state;
-    const {
+	render() {
+		const { modalVisible, selectedOption } = this.state;
+		const {
 			options,
 			buttonStyle,
 			itemStyle,
@@ -173,50 +188,50 @@ class SimplePicker extends Component {
 			disableOverlay,
 		} = this.props;
 
-    return (
-      <Modal
-        animationType={'slide'}
-        transparent
-        visible={modalVisible}
-      >
-        <View style={this.styles.basicContainer}>
+		return (
+			<Modal
+				animationType={'slide'}
+				transparent
+				visible={modalVisible}
+			>
+				<View style={this.styles.basicContainer}>
 					{!disableOverlay &&
-						<View style={this.styles.overlayContainer}>
-							<TouchableWithoutFeedback onPress={this.onOverlayDismiss}>
-								<View style={this.styles.overlayContainer} />
-							</TouchableWithoutFeedback>
-						</View>
+					<View style={this.styles.overlayContainer}>
+						<TouchableWithoutFeedback onPress={this.onOverlayDismiss}>
+							<View style={this.styles.overlayContainer}/>
+						</TouchableWithoutFeedback>
+					</View>
 					}
-          <View style={this.styles.modalContainer}>
-            <View style={this.styles.buttonView}>
-              <TouchableOpacity onPress={this.onPressCancel}>
-                <Text style={buttonStyle}>
-                  {cancelText || 'Cancel'}
-                </Text>
-              </TouchableOpacity>
+					<View style={this.styles.modalContainer}>
+						<View style={this.styles.buttonView}>
+							<TouchableOpacity onPress={this.onPressCancel}>
+								<Text style={buttonStyle}>
+									{cancelText || 'Cancel'}
+								</Text>
+							</TouchableOpacity>
 
-              <TouchableOpacity onPress={this.onPressSubmit}>
-                <Text style={buttonStyle}>
-                  {confirmText || 'Confirm'}
-                </Text>
-              </TouchableOpacity>
-            </View>
-            <View style={this.styles.mainBox}>
-              <Picker
-                ref={'picker'}
-                style={this.styles.bottomPicker}
-                selectedValue={selectedOption}
-                onValueChange={(option) => this.onValueChange(option)}
-                itemStyle={itemStyle}
-              >
-                {options.map((option, index) => this.renderItem(option, index))}
-              </Picker>
-            </View>
-          </View>
-        </View>
-      </Modal>
-    );
-  }
+							<TouchableOpacity onPress={this.onPressSubmit}>
+								<Text style={buttonStyle}>
+									{confirmText || 'Confirm'}
+								</Text>
+							</TouchableOpacity>
+						</View>
+						<View style={this.styles.mainBox}>
+							<Picker
+								ref={'picker'}
+								style={this.styles.bottomPicker}
+								selectedValue={selectedOption}
+								onValueChange={(option) => this.onValueChange(option)}
+								itemStyle={itemStyle}
+							>
+								{options.map((option, index) => this.renderItem(option, index))}
+							</Picker>
+						</View>
+					</View>
+				</View>
+			</Modal>
+		);
+	}
 }
 
 SimplePicker.propTypes = propTypes;

--- a/index.js
+++ b/index.js
@@ -10,12 +10,10 @@ import {
   TouchableOpacity,
   View,
   Modal,
-  PickerIOS,
+  Picker,
   Dimensions,
   TouchableWithoutFeedback,
 } from 'react-native';
-
-const PickerItemIOS = PickerIOS.Item;
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 
@@ -64,6 +62,7 @@ const propTypes = {
   itemStyle: PropTypes.object,
   onSubmit: PropTypes.func,
   disableOverlay: PropTypes.bool,
+	modalVisible: PropTypes.string,
 };
 
 class SimplePicker extends Component {
@@ -73,7 +72,7 @@ class SimplePicker extends Component {
     const selected = this.props.initialOptionIndex || 0;
 
     this.state = {
-      modalVisible: false,
+      modalVisible: PropTypes.modalVisible || false,
       selectedOption: this.props.options[selected],
     };
 
@@ -146,7 +145,7 @@ class SimplePicker extends Component {
     const label = (this.props.labels) ? this.props.labels[index] : option;
 
     return (
-      <PickerItemIOS
+      <Picker.Item
         key={option}
         value={option}
         label={label}
@@ -194,7 +193,7 @@ class SimplePicker extends Component {
               </TouchableOpacity>
             </View>
             <View style={styles.mainBox}>
-              <PickerIOS
+              <Picker
                 ref={'picker'}
                 style={styles.bottomPicker}
                 selectedValue={selectedOption}
@@ -202,7 +201,7 @@ class SimplePicker extends Component {
                 itemStyle={itemStyle}
               >
                 {options.map((option, index) => this.renderItem(option, index))}
-              </PickerIOS>
+              </Picker>
             </View>
           </View>
         </View>

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ import {
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 
-const styles = StyleSheet.create({
+const styles = {
   basicContainer: {
     flex: 1,
     justifyContent: 'flex-end',
@@ -27,6 +27,10 @@ const styles = StyleSheet.create({
   overlayContainer: {
     flex: 1,
     width: SCREEN_WIDTH,
+  },
+
+  mainBox: {
+   // Can be used by <SimplePicker styles={{ mainBox:{...} }}/>
   },
 
   modalContainer: {
@@ -49,34 +53,39 @@ const styles = StyleSheet.create({
   bottomPicker: {
     width: SCREEN_WIDTH,
   },
-});
+};
 
 const propTypes = {
   buttonColor: PropTypes.string,
   buttonStyle: PropTypes.object,
-  options: PropTypes.array.isRequired,
-  initialOptionIndex: PropTypes.number,
-  labels: PropTypes.array,
-  confirmText: PropTypes.string,
   cancelText: PropTypes.string,
-  itemStyle: PropTypes.object,
-  onSubmit: PropTypes.func,
+  confirmText: PropTypes.string,
   disableOverlay: PropTypes.bool,
-	modalVisible: PropTypes.string,
+  initialOptionIndex: PropTypes.number,
+  itemStyle: PropTypes.object,
+  labels: PropTypes.array,
+  modalVisible: PropTypes.string,
+  onSubmit: PropTypes.func,
+	options: PropTypes.array.isRequired,
+	styles: PropTypes.object,
 };
 
 class SimplePicker extends Component {
-  constructor(props) {
+	static defaultProps = {
+		styles: {}
+	};
+	constructor(props) {
     super(props);
 
-    const selected = this.props.initialOptionIndex || 0;
+    const selected = props.initialOptionIndex || 0;
 
     this.state = {
-      modalVisible: PropTypes.modalVisible || false,
-      selectedOption: this.props.options[selected],
+      modalVisible: props.modalVisible || false,
+      selectedOption: props.options[selected],
     };
+		this.styles = StyleSheet.create({...styles, ...props.styles});
 
-    this.onPressCancel = this.onPressCancel.bind(this);
+		this.onPressCancel = this.onPressCancel.bind(this);
     this.onPressSubmit = this.onPressSubmit.bind(this);
     this.onValueChange = this.onValueChange.bind(this);
     this.onOverlayDismiss = this.onOverlayDismiss.bind(this);
@@ -170,16 +179,16 @@ class SimplePicker extends Component {
         transparent
         visible={modalVisible}
       >
-        <View style={styles.basicContainer}>
+        <View style={this.styles.basicContainer}>
 					{!disableOverlay &&
-						<View style={styles.overlayContainer}>
+						<View style={this.styles.overlayContainer}>
 							<TouchableWithoutFeedback onPress={this.onOverlayDismiss}>
-								<View style={styles.overlayContainer} />
+								<View style={this.styles.overlayContainer} />
 							</TouchableWithoutFeedback>
 						</View>
 					}
-          <View style={styles.modalContainer}>
-            <View style={styles.buttonView}>
+          <View style={this.styles.modalContainer}>
+            <View style={this.styles.buttonView}>
               <TouchableOpacity onPress={this.onPressCancel}>
                 <Text style={buttonStyle}>
                   {cancelText || 'Cancel'}
@@ -192,10 +201,10 @@ class SimplePicker extends Component {
                 </Text>
               </TouchableOpacity>
             </View>
-            <View style={styles.mainBox}>
+            <View style={this.styles.mainBox}>
               <Picker
                 ref={'picker'}
-                style={styles.bottomPicker}
+                style={this.styles.bottomPicker}
                 selectedValue={selectedOption}
                 onValueChange={(option) => this.onValueChange(option)}
                 itemStyle={itemStyle}

--- a/index.js
+++ b/index.js
@@ -64,7 +64,7 @@ const propTypes = {
   initialOptionIndex: PropTypes.number,
   itemStyle: PropTypes.object,
   labels: PropTypes.array,
-  modalVisible: PropTypes.string,
+  modalVisible: PropTypes.bool,
   onSubmit: PropTypes.func,
 	options: PropTypes.array.isRequired,
 	styles: PropTypes.object,


### PR DESCRIPTION
Added ability to control initial state of picker, without using `ref` , which can be useful when one uses react stateless components (as they do not have `ref`)