### PR TITLE
Added separate Confirm and Cancel text style props

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ You will find an example in the `/exampleApp` folder.
 | initialOptionIndex | - | `Number` | Initial selected option based on it's index | `false`
 | labels | - | `Array` | Labels for the options passed to the picker | `false`
 | confirmText | Confirm | `String` | Confirm button text | `false`
+| confirmTextStyle | - | `Object` | Style Confirm button text | `false`
 | cancelText | Cancel | `String` | Cancel button text | `false`
+| cancelTextStyle | - | `Object` | Style Close button text | `false`
 | itemStyle | - | `Object` | Picker style prop. Use this to customize the picker colors, etc | `false`
 | styles | - | `Object` | Overwrites the default [styles](/index.js#L18-L54) of the picker  | `false`
 | disableOverlay | - | `bool` | When set to false it will dismiss the picker when the outside region is pressed | `false`

--- a/index.js
+++ b/index.js
@@ -57,7 +57,9 @@ const propTypes = {
 	buttonColor: PropTypes.string,
 	buttonStyle: PropTypes.object,
 	cancelText: PropTypes.string,
+  cancelTextStyle: PropTypes.object,
 	confirmText: PropTypes.string,
+  confirmTextStyle: PropTypes.object,
 	disableOverlay: PropTypes.bool,
 	initialOptionIndex: PropTypes.number,
 	itemStyle: PropTypes.object,
@@ -188,7 +190,9 @@ class SimplePicker extends Component {
 			buttonStyle,
 			itemStyle,
 			cancelText,
+      cancelTextStyle,
 			confirmText,
+      confirmTextStyle,
 			disableOverlay,
 		} = this.props;
 
@@ -209,13 +213,13 @@ class SimplePicker extends Component {
 					<View style={this.styles.modalContainer}>
 						<View style={this.styles.buttonView}>
 							<TouchableOpacity onPress={this.onPressCancel}>
-								<Text style={buttonStyle}>
+								<Text style={[buttonStyle, cancelTextStyle]}>
 									{cancelText || 'Cancel'}
 								</Text>
 							</TouchableOpacity>
 
 							<TouchableOpacity onPress={this.onPressSubmit}>
-								<Text style={buttonStyle}>
+								<Text style={[buttonStyle, confirmTextStyle]}>
 									{confirmText || 'Confirm'}
 								</Text>
 							</TouchableOpacity>


### PR DESCRIPTION
It's useful to have separate control over the style of the Confirm and Cancel buttons. For example, the Confirm button might be bolded, have different font size and/or have a different colour to the Cancel button. I have added two optional props `confirmTextStyle` and `cancelTextStyle` to complement the existing `buttonStyle` prop.
