### PR TITLE
Added onRequestClose callback to Modal, which calls onPressCancel function

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,6 +201,7 @@ class SimplePicker extends Component {
 				animationType={'slide'}
 				transparent
 				visible={modalVisible}
+        onRequestClose={this.onPressCancel}
 			>
 				<View style={this.styles.basicContainer}>
 					{!disableOverlay &&


### PR DESCRIPTION
Fixing the following warning message that appears on Android:

"Warning: Failed prop type: Required prop onRequestClose was not specified in the Modal"

(see issue https://github.com/puredazzle/react-native-simple-picker/issues/35)