### PR TITLE
Changed Picker to @react-native-picker/picker

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,13 +8,14 @@ import {
 	TouchableOpacity,
 	View,
 	Modal,
-	Picker,
 	Dimensions,
 	TouchableWithoutFeedback,
   Animated,
 	SafeAreaView,
   Platform,
 } from 'react-native'; // eslint-disable-line
+
+import { Picker } from '@react-native-picker/picker';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-plugin-react-native": "^3.2.1"
   },
   "dependencies": {
+    "@react-native-picker/picker": "^2.1.0",
     "prop-types": "^15.5.10"
   }
 }


### PR DESCRIPTION
Fixes #48 

Since in react native v 0.66 Picker is deprecated this changes Picker to be taken from @react-native-picker/picker